### PR TITLE
Adicionando contagem de participantes na listagem de eventos de um responsável

### DIFF
--- a/server/src/database/respositories/EventPrismaRepository.ts
+++ b/server/src/database/respositories/EventPrismaRepository.ts
@@ -20,7 +20,9 @@ export class EventPrismaRepository implements EventRepository {
     return event;
   }
 
-  async findByResponsibleId(responsibleId: string): Promise<Event[]> {
+  async findByResponsibleId(
+    responsibleId: string,
+  ): Promise<(Event & { participants: number })[]> {
     const events = await this.prismaService.event.findMany({
       where: {
         responsibleId,
@@ -28,9 +30,25 @@ export class EventPrismaRepository implements EventRepository {
       orderBy: {
         createDate: 'asc',
       },
+      include: {
+        _count: {
+          select: {
+            Participant: true,
+          },
+        },
+      },
     });
 
-    return events;
+    return events.map((event) => {
+      const participants = event._count.Participant;
+
+      delete event._count;
+
+      return {
+        ...event,
+        participants,
+      };
+    });
   }
 
   async findOneEventByResponsibleId(

--- a/server/src/event/repositories/EventRepository.ts
+++ b/server/src/event/repositories/EventRepository.ts
@@ -4,7 +4,9 @@ import { CreateEventDTO } from '@/event/dtos/CreateEventDTO';
 
 export abstract class EventRepository {
   abstract findById(id: string): Promise<EventPrisma | null>;
-  abstract findByResponsibleId(responsibleId: string): Promise<EventPrisma[]>;
+  abstract findByResponsibleId(
+    responsibleId: string,
+  ): Promise<(EventPrisma & { participants: number })[]>;
   abstract findOneEventByResponsibleId(
     id: string,
     responsibleId: string,

--- a/server/src/event/useCases/ListEventsByResponsibleIdUseCase.spec.ts
+++ b/server/src/event/useCases/ListEventsByResponsibleIdUseCase.spec.ts
@@ -58,4 +58,45 @@ describe('List Events By Responsible', () => {
 
     expect(eventsResponsible).toHaveLength(0);
   });
+
+  it('should be able list count participants with events', async () => {
+    const responsible = await responsibleRepositoryInMemory.create({
+      name: faker.person.fullName(),
+      email: faker.internet.email(),
+      phoneNumber: faker.phone.number(),
+      password: '123',
+    });
+
+    const event = await eventRepositoryInMemory.create({
+      name: 'Event Test',
+      type: TypeEvent.SOCCER,
+      description: 'Event test created',
+      responsibleId: responsible.id,
+    });
+
+    await Promise.all([
+      eventRepositoryInMemory.createParticipantEvent({
+        name: faker.person.fullName(),
+        eventId: event.id,
+        phoneNumber: faker.phone.number(),
+      }),
+      eventRepositoryInMemory.createParticipantEvent({
+        name: faker.person.fullName(),
+        eventId: event.id,
+        phoneNumber: faker.phone.number(),
+      }),
+      eventRepositoryInMemory.createParticipantEvent({
+        name: faker.person.fullName(),
+        eventId: event.id,
+        phoneNumber: faker.phone.number(),
+      }),
+    ]);
+
+    const [firstEvent] = await listEventsByResponsibleIdUseCase.execute(
+      responsible.id,
+    );
+
+    expect(firstEvent).toHaveProperty('participants');
+    expect(firstEvent.participants).toEqual(3);
+  });
 });


### PR DESCRIPTION
Para essa implementação foram feitos alguns ajustes:

- Ajuste na tipagem do retorno na classe repositório abstrata do evento.
- Ajuste no método de listagem de eventos de um responsável no repositório de implementação utilizando Prisma.
- Ajuste no método de listagem de eventos de um responsável no repositório de implementação in-memory.
- Ajuste nos testes de listagem de eventos de um responsável.