### PR TITLE
Adicionando suporte do campo data de criação no serviço de novo histórico.

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/platform-express": "^10.0.0",
         "@prisma/client": "^5.19.1",
         "bcrypt": "^5.1.1",
+        "date-fns": "^4.1.0",
         "jest-extended": "^4.0.2",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
@@ -3712,6 +3713,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,7 @@
     "@nestjs/platform-express": "^10.0.0",
     "@prisma/client": "^5.19.1",
     "bcrypt": "^5.1.1",
+    "date-fns": "^4.1.0",
     "jest-extended": "^4.0.2",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",

--- a/server/src/database/respositories/HistoryPrismaRepository.ts
+++ b/server/src/database/respositories/HistoryPrismaRepository.ts
@@ -93,6 +93,7 @@ export class HistoryPrismaRepository implements HistoryRepository {
     type,
     eventId,
     participantId,
+    createDate,
   }: CreateHistoryDTO): Promise<HistoryPrisma> {
     const historyData = {
       name,
@@ -101,6 +102,7 @@ export class HistoryPrismaRepository implements HistoryRepository {
       eventId,
       participantId,
       status: true,
+      createDate,
     };
 
     const history = await this.prismaService.history.create({

--- a/server/src/history/dtos/CreateHistoryDTO.ts
+++ b/server/src/history/dtos/CreateHistoryDTO.ts
@@ -4,4 +4,5 @@ export interface CreateHistoryDTO {
   type: string;
   participantId: string;
   eventId: string;
+  createDate?: string | Date;
 }

--- a/server/src/history/useCases/CreateHistoryUseCase.spec.ts
+++ b/server/src/history/useCases/CreateHistoryUseCase.spec.ts
@@ -9,6 +9,7 @@ import { ParticipantRepositoryInMemory } from '../../../test/repositories/Partic
 
 import { CreateHistoryUseCase } from './CreateHistoryUseCase';
 import { TypeHistory } from '../enums/typeHistory.enum';
+import { addDays, addMonths, addYears, format } from 'date-fns';
 
 let historyRepositoryInMemory: HistoryRepositoryInMemory;
 let eventRespositoryInMemory: EventRepositoryInMemory;
@@ -180,6 +181,70 @@ describe('Create history', () => {
       });
     }).rejects.toEqual(
       new BadRequestException('The value cannot be less than zero!'),
+    );
+  });
+
+  it('should be able create history with create date (before) in body', async () => {
+    const event = await eventRespositoryInMemory.create({
+      name: 'Event Test',
+      description: 'Event Test',
+      responsibleId: 'responsible-id',
+      type: TypeEvent.SOCCER,
+      dayMonthly: '06',
+      valueMonthly: 800,
+    });
+
+    const participant = await participantRepositoryInMemory.create({
+      name: faker.person.fullName(),
+      eventId: event.id,
+      phoneNumber: faker.phone.number(),
+    });
+
+    const history = await createHistoryUseCase.execute({
+      value: 30,
+      eventId: event.id,
+      participantId: participant.id,
+      type: TypeHistory.MONTHLY,
+      createDate: '2024-10-19', // É possivel enviar datas passadas para complementar historicos antigos
+    });
+
+    expect(history.createDate.getDate()).toBe(19);
+    expect(history.createDate.getMonth() + 1).toBe(10);
+    expect(history.createDate).not.toEqual(new Date());
+  });
+
+  it('should not be able create history with month in create date', async () => {
+    expect(async () => {
+      return createHistoryUseCase.execute({
+        value: 50,
+        eventId: 'event-id',
+        participantId: 'participant-id',
+        type: TypeHistory.MONTHLY,
+        createDate: '2024-15-19',
+      });
+    }).rejects.toEqual(
+      new BadRequestException('Create Date for history is invalid!'),
+    );
+  });
+
+  it('should not be able create history with after create date', async () => {
+    const today = new Date();
+
+    // Adiciona 15 dias, 2 meses e 1 ano para frente
+    const futureDate = addYears(addMonths(addDays(today, 15), 2), 1);
+
+    const futureCreateDate = format(futureDate, 'yyyy-MM-dd');
+
+    expect(async () => {
+      return createHistoryUseCase.execute({
+        value: 50,
+        eventId: 'event-id',
+        participantId: 'participant-id',
+        type: TypeHistory.MONTHLY,
+        createDate: futureCreateDate,
+      });
+    }).rejects.toEqual(
+      new BadRequestException('The create date cannot be a future date!'),
     );
   });
 });

--- a/server/src/history/useCases/CreateHistoryUseCase.ts
+++ b/server/src/history/useCases/CreateHistoryUseCase.ts
@@ -3,6 +3,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
+import { isAfter, isValid, parseISO, startOfDay } from 'date-fns';
 
 import { CreateHistoryDTO } from '../dtos/CreateHistoryDTO';
 
@@ -24,7 +25,25 @@ export class CreateHistoryUseCase {
     type,
     eventId,
     participantId,
+    createDate,
   }: CreateHistoryDTO) {
+    const currentDate = new Date();
+    let createDateToDate = currentDate;
+
+    if (createDate) {
+      createDateToDate = parseISO(String(createDate));
+
+      if (!isValid(createDateToDate)) {
+        throw new BadRequestException('Create Date for history is invalid!');
+      }
+
+      // Rever se precisar realmente barrar uma data futura posteriormente pos MVP ou testes
+      if (isAfter(startOfDay(createDateToDate), startOfDay(currentDate))) {
+        throw new BadRequestException(
+          'The create date cannot be a future date!',
+        );
+      }
+    }
     const event = await this.eventRepository.findById(eventId);
 
     if (!event) {
@@ -54,12 +73,10 @@ export class CreateHistoryUseCase {
     }
 
     if (!name) {
-      const today = new Date();
-
-      const year = today.getFullYear();
-      const month = today.getMonth() + 1;
+      const year = createDateToDate.getFullYear();
+      const month = createDateToDate.getMonth() + 1;
       const monthFormatted = month < 10 ? `0${month}` : month;
-      const date = today.getDate();
+      const date = createDateToDate.getDate();
 
       name = `Nova Transação - ${date}/${monthFormatted}/${year}`;
     }
@@ -70,6 +87,7 @@ export class CreateHistoryUseCase {
       type,
       eventId,
       participantId,
+      createDate: createDateToDate,
     };
 
     const history = await this.historyRepository.create(newHistory);


### PR DESCRIPTION
Para essa implementação foram feitos os seguintes ajustes:

- Adição da lib date-fns no servidor.
- Colocando o campo createDate como opcional no DTO.
- Adicionando casos de testes, enviando o campo createDate.