### PR TITLE
Adicionando coluna de status na entidade de participantes

### DIFF
--- a/server/prisma/migrations/20241027185520_add_status_columns_participant_entity/migration.sql
+++ b/server/prisma/migrations/20241027185520_add_status_columns_participant_entity/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `Participant` ADD COLUMN `status` BOOLEAN NULL DEFAULT true;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -34,6 +34,7 @@ model Participant {
   phoneNumber String?
   avatar      String?
   eventId     String
+  status      Boolean?  @default(true)
   event       Event     @relation(fields: [eventId], references: [id])
   createDate  DateTime? @default(now())
   updateDate  DateTime? @default(now())

--- a/server/src/database/respositories/ParticipantPrismaRepository.ts
+++ b/server/src/database/respositories/ParticipantPrismaRepository.ts
@@ -18,7 +18,7 @@ export class ParticipantPrismaRepository implements ParticipantRepository {
 
     return participant;
   }
-  async findByEventId(
+  async findActiveByEventId(
     nameParticipant: string,
     eventId: string,
   ): Promise<Participant | null> {
@@ -27,6 +27,7 @@ export class ParticipantPrismaRepository implements ParticipantRepository {
         AND: [
           {
             name: nameParticipant,
+            status: true,
           },
           {
             eventId,

--- a/server/src/history/useCases/CreateHistoryUseCase.spec.ts
+++ b/server/src/history/useCases/CreateHistoryUseCase.spec.ts
@@ -151,7 +151,7 @@ describe('Create history', () => {
         type: TypeHistory.MONTHLY,
       });
     }).rejects.toEqual(
-      new NotFoundException('The participant is not present at the event!'),
+      new NotFoundException('The participant is not active at the event!'),
     );
   });
 

--- a/server/src/history/useCases/CreateHistoryUseCase.ts
+++ b/server/src/history/useCases/CreateHistoryUseCase.ts
@@ -57,14 +57,15 @@ export class CreateHistoryUseCase {
       throw new NotFoundException('Participant not found!');
     }
 
-    const participantInEvent = await this.participantRepository.findByEventId(
-      participant.name,
-      eventId,
-    );
+    const participantActiveInEvent =
+      await this.participantRepository.findActiveByEventId(
+        participant.name,
+        eventId,
+      );
 
-    if (!participantInEvent) {
+    if (!participantActiveInEvent) {
       throw new NotFoundException(
-        'The participant is not present at the event!',
+        'The participant is not active at the event!',
       );
     }
 

--- a/server/src/participant/dtos/CreateParticipantDTO.ts
+++ b/server/src/participant/dtos/CreateParticipantDTO.ts
@@ -4,4 +4,5 @@ export interface CreateParticipantDTO {
   phoneNumber: string;
   avatar?: string;
   eventId: string;
+  status?: boolean;
 }

--- a/server/src/participant/dtos/UpdateParticipantDTO.ts
+++ b/server/src/participant/dtos/UpdateParticipantDTO.ts
@@ -3,4 +3,5 @@ export interface UpdateParticipantDTO {
   phoneNumber?: string;
   email?: string;
   avatar?: string;
+  status?: boolean;
 }

--- a/server/src/participant/participant.controller.ts
+++ b/server/src/participant/participant.controller.ts
@@ -1,12 +1,15 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Param, Post, Put } from '@nestjs/common';
 
 import { CreateParticipantUseCase } from './useCases/CreateParticipantUseCase';
 import { CreateParticipantDTO } from './dtos/CreateParticipantDTO';
+import { UpdateParticipantUseCase } from './useCases/UpdateParticipantUseCase';
+import { UpdateParticipantDTO } from './dtos/UpdateParticipantDTO';
 
 @Controller('/participants')
 export class ParticipantController {
   constructor(
     private readonly createParticipantUseCase: CreateParticipantUseCase,
+    private readonly updateParticipantUseCase: UpdateParticipantUseCase,
   ) {}
 
   @Post('/')
@@ -15,5 +18,18 @@ export class ParticipantController {
       await this.createParticipantUseCase.execute(createParticipantDTO);
 
     return participant;
+  }
+
+  @Put('/:participantId')
+  async updateById(
+    @Param('participantId') participantId: string,
+    @Body() updateParticipantDTO: UpdateParticipantDTO,
+  ) {
+    const participantUpdated = await this.updateParticipantUseCase.execute(
+      participantId,
+      updateParticipantDTO,
+    );
+
+    return participantUpdated;
   }
 }

--- a/server/src/participant/participant.module.ts
+++ b/server/src/participant/participant.module.ts
@@ -2,12 +2,14 @@ import { Module } from '@nestjs/common';
 
 import { DatabaseModule } from '@/database/database.module';
 
-import { ParticipantController } from './participant.controller';
 import { CreateParticipantUseCase } from './useCases/CreateParticipantUseCase';
+import { UpdateParticipantUseCase } from './useCases/UpdateParticipantUseCase';
+
+import { ParticipantController } from './participant.controller';
 
 @Module({
   imports: [DatabaseModule],
   controllers: [ParticipantController],
-  providers: [CreateParticipantUseCase],
+  providers: [CreateParticipantUseCase, UpdateParticipantUseCase],
 })
 export class ParticipantModule {}

--- a/server/src/participant/repositories/ParticipantRepository.ts
+++ b/server/src/participant/repositories/ParticipantRepository.ts
@@ -5,7 +5,7 @@ import { UpdateParticipantDTO } from '@/participant/dtos/UpdateParticipantDTO';
 
 export abstract class ParticipantRepository {
   abstract findById(id: string): Promise<ParticipantPrisma>;
-  abstract findByEventId(
+  abstract findActiveByEventId(
     nameParticipant: string,
     eventId: string,
   ): Promise<ParticipantPrisma | null>;

--- a/server/src/participant/useCases/CreateParticipantUseCase.ts
+++ b/server/src/participant/useCases/CreateParticipantUseCase.ts
@@ -15,23 +15,35 @@ export class CreateParticipantUseCase {
     private eventRepository: EventRepository,
   ) {}
 
-  async execute(data: CreateParticipantDTO) {
-    const eventAlreadyExists = await this.eventRepository.findById(
-      data.eventId,
-    );
+  async execute({
+    name,
+    eventId,
+    phoneNumber,
+    avatar,
+    email,
+    status,
+  }: CreateParticipantDTO) {
+    const eventAlreadyExists = await this.eventRepository.findById(eventId);
 
     if (!eventAlreadyExists) {
       throw new NotFoundException('Event not found!');
     }
 
-    const participantAlreadyExists =
-      await this.participantRepository.findByEventId(data.name, data.eventId);
+    const participantActiveInEvent =
+      await this.participantRepository.findActiveByEventId(name, eventId);
 
-    if (participantAlreadyExists) {
+    if (participantActiveInEvent) {
       throw new BadRequestException('Participant already exists in event!');
     }
 
-    const participant = await this.participantRepository.create(data);
+    const participant = await this.participantRepository.create({
+      name,
+      eventId,
+      phoneNumber,
+      avatar,
+      email,
+      status: status ?? true,
+    });
 
     return participant;
   }

--- a/server/src/participant/useCases/UpdateParticipantUseCase.spec.ts
+++ b/server/src/participant/useCases/UpdateParticipantUseCase.spec.ts
@@ -152,4 +152,39 @@ describe('Update Participant', () => {
       participantAfterUpdate.name,
     );
   });
+
+  it('should be able update status a participant', async () => {
+    const participantOne = await participantRepositoryInMemory.create({
+      name: faker.person.fullName(),
+      eventId: eventId,
+      phoneNumber: faker.phone.number(),
+      email: faker.internet.email(),
+    });
+
+    const participantTwo = await participantRepositoryInMemory.create({
+      name: faker.person.fullName(),
+      eventId: eventId,
+      phoneNumber: faker.phone.number(),
+      email: faker.internet.email(),
+    });
+
+    await updateParticipantUseCase.execute(participantTwo.id, {
+      status: false,
+    });
+
+    const participantTwoAfterUpdated =
+      await participantRepositoryInMemory.findById(participantTwo.id);
+
+    const participantStatus = participantRepositoryInMemory.participants.filter(
+      (item) => item.status,
+    );
+
+    expect(participantTwoAfterUpdated.status).toEqual(false);
+    expect(participantRepositoryInMemory.participants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: participantOne.id, status: true }),
+      ]),
+    );
+    expect(participantStatus).toHaveLength(1);
+  });
 });

--- a/server/test/repositories/EventRepositoryInMemory.ts
+++ b/server/test/repositories/EventRepositoryInMemory.ts
@@ -116,6 +116,7 @@ export class EventRepositoryInMemory implements EventRepository {
     phoneNumber,
     avatar,
     eventId,
+    status,
   }: CreateParticipantDTO) {
     const newParticipantEvent = {
       id: randomUUID(),
@@ -124,6 +125,7 @@ export class EventRepositoryInMemory implements EventRepository {
       phoneNumber,
       avatar,
       eventId,
+      status: status ?? true,
       createDate: new Date(),
       updateDate: new Date(),
     };

--- a/server/test/repositories/HistoryRepositoryInMemory.ts
+++ b/server/test/repositories/HistoryRepositoryInMemory.ts
@@ -151,6 +151,7 @@ export class HistoryRepositoryInMemory implements HistoryRepository {
     email,
     phoneNumber,
     avatar,
+    status,
     eventId,
   }: CreateParticipantDTO) {
     const newParticipantEvent = {
@@ -159,6 +160,7 @@ export class HistoryRepositoryInMemory implements HistoryRepository {
       email,
       phoneNumber,
       avatar,
+      status: status ?? true,
       eventId,
       createDate: new Date(),
       updateDate: new Date(),

--- a/server/test/repositories/ParticipantRepositoryInMemory.ts
+++ b/server/test/repositories/ParticipantRepositoryInMemory.ts
@@ -20,12 +20,15 @@ export class ParticipantRepositoryInMemory implements ParticipantRepository {
     return participant;
   }
 
-  async findByEventId(
+  async findActiveByEventId(
     nameParticipant: string,
     eventId: string,
   ): Promise<ParticipantPrisma | null> {
     const participant = this.participants.find(
-      (item) => item.name === nameParticipant && item.eventId === eventId,
+      (item) =>
+        item.status &&
+        item.name === nameParticipant &&
+        item.eventId === eventId,
     );
 
     return participant;
@@ -37,6 +40,7 @@ export class ParticipantRepositoryInMemory implements ParticipantRepository {
     phoneNumber,
     avatar,
     eventId,
+    status,
   }: CreateParticipantDTO): Promise<ParticipantPrisma> {
     const dataParticipant = {
       id: randomUUID(),
@@ -45,6 +49,7 @@ export class ParticipantRepositoryInMemory implements ParticipantRepository {
       phoneNumber,
       avatar,
       eventId,
+      status: status ?? true,
       createDate: new Date(),
       updateDate: new Date(),
     };
@@ -79,6 +84,10 @@ export class ParticipantRepositoryInMemory implements ParticipantRepository {
 
       if (data.avatar) {
         currentParticipant.avatar = data.avatar;
+      }
+
+      if (data.status !== undefined) {
+        currentParticipant.status = data.status;
       }
 
       this.participants[participantIndex] = currentParticipant;

--- a/web/src/components/ModalCreateHistory.tsx
+++ b/web/src/components/ModalCreateHistory.tsx
@@ -54,7 +54,9 @@ export const ModalCreateHistory = ({
 
   const [valueParsed, setValueParsed] = useState<number>(0);
 
-  const optionsParticipants = participants.map((item) => ({
+  const participantsActive = participants.filter((item) => item.status);
+
+  const optionsParticipants = participantsActive.map((item) => ({
     label: item.name,
     value: item.id,
   }));
@@ -116,7 +118,11 @@ export const ModalCreateHistory = ({
       title='Criar nova transação'
       isOpen={modalOpen}
       handleOpen={() => setModalOpen(!modalOpen)}
-      handleClose={() => setModalOpen(false)}
+      handleClose={() => {
+        reset();
+
+        setModalOpen(false);
+      }}
       trigger={() => (
         <Button className='py-1 px-1 w-40 rounded-md'>Nova transação</Button>
       )}

--- a/web/src/components/dashboard/Payments.tsx
+++ b/web/src/components/dashboard/Payments.tsx
@@ -2,16 +2,19 @@ import { useSelector } from "react-redux";
 
 import { EmptyList } from "../EmptyList";
 
+import { getFormatDate } from "../../utils/date";
+import { getMonthPaymentRef } from "../../utils/payment";
+
 import { selectEvent } from "../../store/events/event.slice";
 
 export const Payments = () => {
-  const event = useSelector(selectEvent);
+  const { name, payments } = useSelector(selectEvent);
 
   return (
     <>
       <div className='w-4/5 h-full flex flex-col gap-4 px-3 py-3'>
         <div className=' w-full flex items-center justify-between'>
-          <span className='font-semibold text-xl'>{event.name}</span>
+          <span className='font-semibold text-xl'>{name}</span>
         </div>
 
         <div className='w-full h-full flex flex-col gap-2 py-1 shadow-md overflow-y-auto'>
@@ -21,9 +24,9 @@ export const Payments = () => {
             <span className='text-sm w-36 font-semibold'>Mês Referencia</span>
             <span className='text-sm w-36 font-semibold'>Data Pagamento</span>
           </div>
-          {event.payments.length > 0 ? (
+          {payments.length > 0 ? (
             <>
-              {event.payments.map((payment) => (
+              {payments.map((payment) => (
                 <div className='w-full h-10 flex gap-3 py-2 items-center justify-around border-b border-zinc-200'>
                   <span className='text-sm font-semibold w-2/6'>
                     {payment.name}
@@ -32,10 +35,10 @@ export const Payments = () => {
                     {payment.value}
                   </span>
                   <span className='text-sm w-36 text-zinc-500'>
-                    {payment.paymentRef}
+                    {getMonthPaymentRef(payment.paymentRef)}
                   </span>
                   <span className='text-sm w-36 text-zinc-500'>
-                    {payment.datePayment}
+                    {getFormatDate(new Date(payment.datePayment), "dd/MM/yyyy")}
                   </span>
                 </div>
               ))}

--- a/web/src/interfaces/Participant.interface.ts
+++ b/web/src/interfaces/Participant.interface.ts
@@ -5,6 +5,7 @@ export interface Participant {
   phoneNumber: string;
   avatar: string;
   eventId: string;
+  status: boolean;
   createDate: string;
   updateDate: string;
 }


### PR DESCRIPTION
Foi preciso adicionar essa coluna para obter a ação de ativação e desativação de um participante em um evento, assim na criação de um participante foi validado se o participante existia e se estava ativo para evitar duplicidade de usuários ativos.
Na parte de criação de histórico também foi feita ajustada essa validação.